### PR TITLE
Fix for get_user_by_email

### DIFF
--- a/backend/src/controllers/usercontroller.py
+++ b/backend/src/controllers/usercontroller.py
@@ -32,6 +32,8 @@ class UserController(Controller):
             users = self.dao.find({'email': email})
             if len(users) == 1:
                 return users[0]
+            elif len(users) == 0:
+            	return None
             else:
                 print(f'Error: more than one user found with mail {email}')
                 return users[0]


### PR DESCRIPTION
Fixed get_user_by_email raising an exception instead of returning None when no users are associated with the given email